### PR TITLE
Fix typo in `pkg_add` command in "OpenBSD: system libs" job

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           envs: 'CCACHE_DIR'
           prepare: |
-            pkg_add cmake ccache boost libevent sqlite3 zeromq python% py3-zmq
+            pkg_add cmake ccache boost libevent sqlite3 zeromq python py3-zmq
           run: |
             set -e
             cmake -B build -DWITH_ZMQ=ON -DBUILD_BENCH=ON -DBUILD_FUZZ_BINARY=ON -DWERROR=ON


### PR DESCRIPTION
The `%` was a leftover from experiments with [`pkg_add`](https://man.openbsd.org/pkg_add) postfix notation. As OpenBSD 7.6 includes only one Python 3 port, specifying the version is unnecessary.

See: https://www.ports.to/cat/lang.html.