### PR TITLE
Set `CCACHE_MAXFILES`

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,6 +11,7 @@ concurrency:
 
 env:
   CCACHE_DIR: ${{ github.workspace }}/ccache
+  CCACHE_MAXFILES: 2500
   DEPENDS_CACHE_DIR: ${{ github.workspace }}/depends/built
   # See https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
   CI_NCPU: 4
@@ -39,7 +40,7 @@ jobs:
       - name: Start FreeBSD VM
         uses: vmactions/freebsd-vm@v1
         with:
-          envs: 'CCACHE_DIR'
+          envs: 'CCACHE_DIR CCACHE_MAXFILES'
           prepare: pkg install -y cmake-core pkgconf ccache boost-libs libevent sqlite3 libzmq4 python3 databases/py-sqlite3 net/py-pyzmq
           sync: 'rsync'
           copyback: false
@@ -102,7 +103,7 @@ jobs:
       - name: Start FreeBSD VM
         uses: vmactions/freebsd-vm@v1
         with:
-          envs: 'CCACHE_DIR'
+          envs: 'CCACHE_DIR CCACHE_MAXFILES'
           prepare: pkg install -y bash curl gmake cmake-core perl5 pkgconf ccache python3 databases/py-sqlite3 net/py-pyzmq
           sync: 'rsync'
           copyback: false
@@ -164,7 +165,7 @@ jobs:
       - name: Start OpenBSD VM
         uses: vmactions/openbsd-vm@v1
         with:
-          envs: 'CCACHE_DIR'
+          envs: 'CCACHE_DIR CCACHE_MAXFILES'
           prepare: pkg_add -v cmake ccache boost libevent sqlite3 zeromq python py3-zmq
           sync: 'rsync'
           copyback: false
@@ -226,7 +227,7 @@ jobs:
       - name: Start OpenBSD VM
         uses: vmactions/openbsd-vm@v1
         with:
-          envs: 'CCACHE_DIR'
+          envs: 'CCACHE_DIR CCACHE_MAXFILES'
           prepare: pkg_add bash curl gmake gtar-- cmake ccache python py3-zmq
           sync: 'rsync'
           copyback: false
@@ -289,7 +290,7 @@ jobs:
       - name: Start NetBSD VM
         uses: vmactions/netbsd-vm@v1
         with:
-          envs: 'CCACHE_DIR'
+          envs: 'CCACHE_DIR CCACHE_MAXFILES'
           prepare: /usr/sbin/pkg_add cmake gcc14 pkg-config ccache boost-headers libevent sqlite3 db4 zeromq
           sync: 'rsync'
           copyback: false


### PR DESCRIPTION
Cache size varies across OSes. However, setting a common limit for the maximum number of files to keep in the cache appears to be more appropriate.

Fixes "No space left on device" [error](https://github.com/hebasto/bitcoin-core-nightly/actions/runs/12511092189/job/34902721501) on FreeBSD.