### PR TITLE
Set `CCACHE_COMPILERCHECK` to "content"

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,6 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  CCACHE_COMPILERCHECK: content
   CCACHE_DIR: ${{ github.workspace }}/ccache
   CCACHE_MAXFILES: 2500
   DEPENDS_CACHE_DIR: ${{ github.workspace }}/depends/built
@@ -40,7 +41,7 @@ jobs:
       - name: Start FreeBSD VM
         uses: vmactions/freebsd-vm@v1
         with:
-          envs: 'CCACHE_DIR CCACHE_MAXFILES'
+          envs: 'CCACHE_COMPILERCHECK CCACHE_DIR CCACHE_MAXFILES'
           prepare: pkg install -y cmake-core pkgconf ccache boost-libs libevent sqlite3 libzmq4 python3 databases/py-sqlite3 net/py-pyzmq
           sync: 'rsync'
           copyback: false
@@ -103,7 +104,7 @@ jobs:
       - name: Start FreeBSD VM
         uses: vmactions/freebsd-vm@v1
         with:
-          envs: 'CCACHE_DIR CCACHE_MAXFILES'
+          envs: 'CCACHE_COMPILERCHECK CCACHE_DIR CCACHE_MAXFILES'
           prepare: pkg install -y bash curl gmake cmake-core perl5 pkgconf ccache python3 databases/py-sqlite3 net/py-pyzmq
           sync: 'rsync'
           copyback: false
@@ -166,7 +167,7 @@ jobs:
       - name: Start OpenBSD VM
         uses: vmactions/openbsd-vm@v1
         with:
-          envs: 'CCACHE_DIR CCACHE_MAXFILES'
+          envs: 'CCACHE_COMPILERCHECK CCACHE_DIR CCACHE_MAXFILES'
           prepare: pkg_add -v cmake ccache boost libevent sqlite3 zeromq python py3-zmq
           sync: 'rsync'
           copyback: false
@@ -228,7 +229,7 @@ jobs:
       - name: Start OpenBSD VM
         uses: vmactions/openbsd-vm@v1
         with:
-          envs: 'CCACHE_DIR CCACHE_MAXFILES'
+          envs: 'CCACHE_COMPILERCHECK CCACHE_DIR CCACHE_MAXFILES'
           prepare: pkg_add bash curl gmake gtar-- cmake ccache python py3-zmq
           sync: 'rsync'
           copyback: false
@@ -291,7 +292,7 @@ jobs:
       - name: Start NetBSD VM
         uses: vmactions/netbsd-vm@v1
         with:
-          envs: 'CCACHE_DIR CCACHE_MAXFILES'
+          envs: 'CCACHE_COMPILERCHECK CCACHE_DIR CCACHE_MAXFILES'
           prepare: |
             /usr/sbin/pkg_info > packages_before
             /usr/sbin/pkg_add cmake gcc14 pkg-config ccache boost-headers libevent sqlite3 db4 zeromq
@@ -346,7 +347,7 @@ jobs:
       - name: Start OmniOS VM
         uses: vmactions/omnios-vm@v1
         with:
-          envs: 'CCACHE_DIR CCACHE_MAXFILES'
+          envs: 'CCACHE_COMPILERCHECK CCACHE_DIR CCACHE_MAXFILES'
           prepare: |
             pkg list -H -o name,publisher,version > packages_before
             pkg install cmake gcc14 pkg-config ccache sqlite-3 python-312


### PR DESCRIPTION
This PR makes the compiler check more robust by ignoring modification times, ensuring proper caching on OmniOS.