### PR TITLE
Introduce "run-test-suite" composite action

### DIFF
--- a/.github/actions/run-test-suite/action.yml
+++ b/.github/actions/run-test-suite/action.yml
@@ -1,0 +1,35 @@
+name: "Run Bitcoin Core test suite"
+description: "Execute the Bitcoin Core test suite using the fetched unit_test_data/script_assets_test.json file."
+inputs:
+  vm:
+    description: "The virtual machine to run the test suite."
+    required: true
+  build-dir:
+    description: "The project's build directory."
+    required: false
+    default: "${{ github.workspace }}/build"
+  envs:
+    description: "Environment variables for the ctest command."
+    required: false
+    default: ""
+  options:
+    description: "Additional options for the ctest command."
+    required: false
+    default: ""
+  unit-test-data-dir:
+    description: "The location of the script_assets_test.json file."
+    required: false
+    default: "${{ github.workspace }}/qa-assets/unit_test_data"
+
+runs:
+  using: "composite"
+  steps:
+    - shell: bash -e {0}
+      run: |
+        mkdir -p ${{ inputs.unit-test-data-dir }}
+        ./ci/retry/retry -- curl --location --fail https://github.com/bitcoin-core/qa-assets/raw/main/unit_test_data/script_assets_test.json --output ${{ inputs.unit-test-data-dir }}/script_assets_test.json
+        rsync --archive --mkpath ${{ inputs.unit-test-data-dir }}/ ${{ inputs.vm }}:${{ inputs.unit-test-data-dir }}
+
+    - shell: ${{ inputs.vm }} {0}
+      run: |
+        cmake -E env DIR_UNIT_TEST_DATA=${{ inputs.unit-test-data-dir }} ${{ inputs.envs }} ctest --test-dir ${{ inputs.build-dir }} -j ${{ env.CI_NCPU }} --output-on-failure ${{ inputs.options }}

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -52,9 +52,7 @@ jobs:
       - name: Checkout helper actions
         uses: actions/checkout@v4
         with:
-          sparse-checkout: |
-            .github/actions/build-with-ccache/action.yml
-          sparse-checkout-cone-mode: false
+          sparse-checkout: .github/actions
           path: ci/nightly
 
       - name: Generate buildsystem
@@ -77,9 +75,9 @@ jobs:
           ./build/src/bitcoind -version
 
       - name: Run test suite
-        run: |
-          cd ${{ github.workspace }}
-          ctest --test-dir build -j ${{ env.CI_NCPU }} --output-on-failure
+        uses: ./ci/nightly/.github/actions/run-test-suite
+        with:
+          vm: freebsd
 
       - name: Run functional tests
         if: ${{ ! inputs.skip_functional_tests }}
@@ -112,10 +110,7 @@ jobs:
       - name: Checkout helper actions
         uses: actions/checkout@v4
         with:
-          sparse-checkout: |
-            .github/actions/build-depends/action.yml
-            .github/actions/build-with-ccache/action.yml
-          sparse-checkout-cone-mode: false
+          sparse-checkout: .github/actions
           path: ci/nightly
 
       - name: Build depends
@@ -144,9 +139,9 @@ jobs:
           ./build/src/bitcoind -version
 
       - name: Run test suite
-        run: |
-          cd ${{ github.workspace }}
-          ctest --test-dir build -j ${{ env.CI_NCPU }} --output-on-failure
+        uses: ./ci/nightly/.github/actions/run-test-suite
+        with:
+          vm: freebsd
 
       - name: Run functional tests
         if: ${{ ! inputs.skip_functional_tests }}

--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -56,9 +56,7 @@ jobs:
       - name: Checkout helper actions
         uses: actions/checkout@v4
         with:
-          sparse-checkout: |
-            .github/actions/build-with-ccache/action.yml
-          sparse-checkout-cone-mode: false
+          sparse-checkout: .github/actions
           path: ci/nightly
 
       - name: Generate buildsystem
@@ -82,9 +80,9 @@ jobs:
           ./build/src/bitcoind -version
 
       - name: Run test suite
-        run: |
-          cd ${{ github.workspace }}
-          ctest --test-dir build -j ${{ env.CI_NCPU }} --output-on-failure
+        uses: ./ci/nightly/.github/actions/run-test-suite
+        with:
+          vm: netbsd
 
       - name: Run functional tests
         if: ${{ ! inputs.skip_functional_tests }}
@@ -149,10 +147,7 @@ jobs:
       - name: Checkout helper actions
         uses: actions/checkout@v4
         with:
-          sparse-checkout: |
-            .github/actions/build-depends/action.yml
-            .github/actions/build-with-ccache/action.yml
-          sparse-checkout-cone-mode: false
+          sparse-checkout: .github/actions
           path: ci/nightly
 
       - name: Build depends
@@ -183,9 +178,9 @@ jobs:
           ./build/src/bitcoind -version
 
       - name: Run test suite
-        run: |
-          cd ${{ github.workspace }}
-          ctest --test-dir build -j ${{ env.CI_NCPU }} --output-on-failure
+        uses: ./ci/nightly/.github/actions/run-test-suite
+        with:
+          vm: netbsd
 
       - name: Run functional tests
         if: ${{ ! inputs.skip_functional_tests }}

--- a/.github/workflows/omnios.yml
+++ b/.github/workflows/omnios.yml
@@ -57,9 +57,7 @@ jobs:
       - name: Checkout helper actions
         uses: actions/checkout@v4
         with:
-          sparse-checkout: |
-            .github/actions/build-with-ccache/action.yml
-          sparse-checkout-cone-mode: false
+          sparse-checkout: .github/actions
           path: ci/nightly
 
       - name: Generate buildsystem
@@ -88,12 +86,13 @@ jobs:
           ./build/src/bitcoind -version
 
       - name: Run test suite
-        run: |
-          cd ${{ github.workspace }}
-          export LD_LIBRARY_PATH="/opt/gcc-14/lib/amd64:/usr/gnu/lib/amd64"
+        uses: ./ci/nightly/.github/actions/run-test-suite
+        with:
+          vm: omnios
+          envs: 'LD_LIBRARY_PATH="/opt/gcc-14/lib/amd64:/usr/gnu/lib/amd64"'
           # TODO: https://github.com/bitcoin/bitcoin/pull/31580
           # TODO: Fix the code, then enable system_tests.
-          ctest --test-dir build -j ${{ env.CI_NCPU }} --output-on-failure --exclude-regex "^(net_tests|system_tests)$"
+          options: '--exclude-regex "^(net_tests|system_tests)$"'
 
       - name: Run functional tests
         if: ${{ ! inputs.skip_functional_tests }}

--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -52,9 +52,7 @@ jobs:
       - name: Checkout helper actions
         uses: actions/checkout@v4
         with:
-          sparse-checkout: |
-            .github/actions/build-with-ccache/action.yml
-          sparse-checkout-cone-mode: false
+          sparse-checkout: .github/actions
           path: ci/nightly
 
       - name: Generate buildsystem
@@ -77,9 +75,9 @@ jobs:
           ./build/src/bitcoind -version
 
       - name: Run test suite
-        run: |
-          cd ${{ github.workspace }}
-          ctest --test-dir build -j ${{ env.CI_NCPU }} --output-on-failure
+        uses: ./ci/nightly/.github/actions/run-test-suite
+        with:
+          vm: openbsd
 
       - name: Run functional tests
         if: ${{ ! inputs.skip_functional_tests }}
@@ -112,10 +110,7 @@ jobs:
       - name: Checkout helper actions
         uses: actions/checkout@v4
         with:
-          sparse-checkout: |
-            .github/actions/build-depends/action.yml
-            .github/actions/build-with-ccache/action.yml
-          sparse-checkout-cone-mode: false
+          sparse-checkout: .github/actions
           path: ci/nightly
 
       - name: Build depends
@@ -145,9 +140,9 @@ jobs:
           ./build/src/bitcoind -version
 
       - name: Run test suite
-        run: |
-          cd ${{ github.workspace }}
-          ctest --test-dir build -j ${{ env.CI_NCPU }} --output-on-failure
+        uses: ./ci/nightly/.github/actions/run-test-suite
+        with:
+          vm: openbsd
 
       - name: Run functional tests
         if: ${{ ! inputs.skip_functional_tests }}


### PR DESCRIPTION
The new "run-test-suite" composite action fetches the [`unit_test_data/script_assets_test.json`](https://github.com/bitcoin-core/qa-assets/blob/main/unit_test_data/script_assets_test.json)  file and sets the `DIR_UNIT_TEST_DATA` environment variable. This is required to run the [`script_tests/script_assets_test`](https://github.com/bitcoin/bitcoin/blob/433412fd8478923dfdb20044f74c5d1e19fa8dd8/src/test/script_tests.cpp#L1605-L1617):
```C++
BOOST_AUTO_TEST_CASE(script_assets_test)
{
    // See src/test/fuzz/script_assets_test_minimizer.cpp for information on how to generate
    // the script_assets_test.json file used by this test.
    SignatureCache signature_cache{DEFAULT_SIGNATURE_CACHE_BYTES};


    const char* dir = std::getenv("DIR_UNIT_TEST_DATA");
    BOOST_WARN_MESSAGE(dir != nullptr, "Variable DIR_UNIT_TEST_DATA unset, skipping script_assets_test");
    if (dir == nullptr) return;
    auto path = fs::path(dir) / "script_assets_test.json";
    bool exists = fs::exists(path);
    BOOST_WARN_MESSAGE(exists, "File $DIR_UNIT_TEST_DATA/script_assets_test.json not found, skipping script_assets_test");
    if (!exists) return;
```

Please note that the only difference in the `ctest` command output is that the `script_tests` test takes longer to run. To observe the actual difference, https://github.com/bitcoin/bitcoin/pull/31576 is required.