### PR TITLE
Amend "build-depends" composite action

### DIFF
--- a/.github/actions/build-depends/action.yml
+++ b/.github/actions/build-depends/action.yml
@@ -26,19 +26,19 @@ runs:
         path: ${{ inputs.cache-dir }}
         key: ${{ github.job }}-depends-${{ hashFiles('depends/**') }}
 
-    - shell: bash -e {0}
-      run: >
-        if test -d ${{ inputs.cache-dir }}; then
-          rsync --archive --stats ${{ inputs.cache-dir }}/ ${{ inputs.vm }}:${{ inputs.cache-dir }}
-        fi
+    - if: steps.restore-cache.outputs.cache-hit == 'true'
+      shell: bash -e {0}
+      run: rsync --archive --stats ${{ inputs.cache-dir }}/ ${{ inputs.vm }}:${{ inputs.cache-dir }}
 
     - shell: ${{ inputs.vm }} {0}
       run: gmake -C ${{ github.workspace }}/depends -j ${{ env.CI_NCPU }} ${{ inputs.host }} BASE_CACHE=${{ inputs.cache-dir }} ${{ inputs.options }} LOG=1
 
-    - shell: bash -e {0}
+    - if: steps.restore-cache.outputs.cache-hit != 'true'
+      shell: bash -e {0}
       run: rsync --archive --stats ${{ inputs.vm }}:${{ inputs.cache-dir }}/ ${{ inputs.cache-dir }}
 
-    - uses: actions/cache/save@v4
+    - if: steps.restore-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
       with:
         path: ${{ inputs.cache-dir }}
         key: ${{ steps.restore-cache.outputs.cache-primary-key }}

--- a/.github/actions/build-depends/action.yml
+++ b/.github/actions/build-depends/action.yml
@@ -8,8 +8,12 @@ inputs:
     description: "The HOST variable definition."
     required: false
     default: ""
+  cache-dir:
+    description: "The built packages cache directory."
+    required: false
+    default: "${{ github.workspace }}/depends/built"
   options:
-    description: "The depends build options."
+    description: "Additional depends build options."
     required: false
     default: ""
 
@@ -19,25 +23,22 @@ runs:
     - uses: actions/cache/restore@v4
       id: restore-cache
       with:
-        path: ${{ env.DEPENDS_CACHE_DIR }}
+        path: ${{ inputs.cache-dir }}
         key: ${{ github.job }}-depends-${{ hashFiles('depends/**') }}
 
     - shell: bash -e {0}
       run: >
-        if test -d ${{ env.DEPENDS_CACHE_DIR }}; then
-          rsync --archive --stats ${{ env.DEPENDS_CACHE_DIR }}/ ${{ inputs.vm }}:${{ env.DEPENDS_CACHE_DIR }}
+        if test -d ${{ inputs.cache-dir }}; then
+          rsync --archive --stats ${{ inputs.cache-dir }}/ ${{ inputs.vm }}:${{ inputs.cache-dir }}
         fi
 
     - shell: ${{ inputs.vm }} {0}
-      run: |
-        cd ${{ github.workspace }}
-        gmake -C depends -j ${{ env.CI_NCPU }} ${{ inputs.host }} ${{ inputs.options }} LOG=1
+      run: gmake -C ${{ github.workspace }}/depends -j ${{ env.CI_NCPU }} ${{ inputs.host }} BASE_CACHE=${{ inputs.cache-dir }} ${{ inputs.options }} LOG=1
 
     - shell: bash -e {0}
-      run: |
-        rsync --archive --stats ${{ inputs.vm }}:${{ env.DEPENDS_CACHE_DIR }}/ ${{ env.DEPENDS_CACHE_DIR }}
+      run: rsync --archive --stats ${{ inputs.vm }}:${{ inputs.cache-dir }}/ ${{ inputs.cache-dir }}
 
     - uses: actions/cache/save@v4
       with:
-        path: ${{ env.DEPENDS_CACHE_DIR }}
+        path: ${{ inputs.cache-dir }}
         key: ${{ steps.restore-cache.outputs.cache-primary-key }}

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -22,7 +22,6 @@ env:
   CCACHE_COMPILERCHECK: content
   CCACHE_DIR: ${{ github.workspace }}/ccache
   CCACHE_MAXFILES: 2400
-  DEPENDS_CACHE_DIR: ${{ github.workspace }}/depends/built
   # See https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
   CI_NCPU: 4
 

--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -22,7 +22,6 @@ env:
   CCACHE_COMPILERCHECK: content
   CCACHE_DIR: ${{ github.workspace }}/ccache
   CCACHE_MAXFILES: 1600
-  DEPENDS_CACHE_DIR: ${{ github.workspace }}/depends/built
   # See https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
   CI_NCPU: 4
 

--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -22,7 +22,6 @@ env:
   CCACHE_COMPILERCHECK: content
   CCACHE_DIR: ${{ github.workspace }}/ccache
   CCACHE_MAXFILES: 1600
-  DEPENDS_CACHE_DIR: ${{ github.workspace }}/depends/built
   # See https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
   CI_NCPU: 4
 


### PR DESCRIPTION
This PR:

1. Fixes "Failed to save: Unable to reserve cache with key ..." errors.

2. Removes global `DEPENDS_CACHE_DIR` environment variables.