### PR TITLE
FreeBSD: Remove `perl5` package installation

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -102,7 +102,7 @@ jobs:
         uses: vmactions/freebsd-vm@v1
         with:
           envs: 'CCACHE_COMPILERCHECK CCACHE_DIR CCACHE_MAXSIZE CCACHE_COMPRESS'
-          prepare: pkg install -y bash curl gmake cmake-core git perl5 pkgconf ccache python3 databases/py-sqlite3 net/py-pyzmq
+          prepare: pkg install -y bash curl gmake cmake-core git pkgconf ccache python3 databases/py-sqlite3 net/py-pyzmq
           run: git config --global --add safe.directory ${{ github.workspace }}
           sync: 'rsync'
           copyback: false


### PR DESCRIPTION
The `perl5` package is no longer required as of bitcoin/bitcoin#31626.