### PR TITLE
FreeBSD: Switch to versioned Python packages

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -44,7 +44,7 @@ jobs:
         uses: vmactions/freebsd-vm@v1
         with:
           envs: 'CCACHE_COMPILERCHECK CCACHE_DIR CCACHE_MAXSIZE CCACHE_COMPRESS'
-          prepare: pkg install -y cmake-core git pkgconf ccache boost-libs libevent sqlite3 libzmq4 python3 databases/py-sqlite3 net/py-pyzmq
+          prepare: pkg install -y cmake-core git pkgconf ccache boost-libs libevent sqlite3 libzmq4 python311 py311-pyzmq py311-sqlite3
           run: git config --global --add safe.directory ${{ github.workspace }}
           sync: 'rsync'
           copyback: false
@@ -83,7 +83,7 @@ jobs:
         if: ${{ ! inputs.skip_functional_tests }}
         run: |
           cd ${{ github.workspace }}
-          ./build/test/functional/test_runner.py --ci --extended -j ${{ env.CI_NCPU }} --combinedlogslen=99999999 --quiet --timeout-factor=8
+          python3.11 ./build/test/functional/test_runner.py --ci --extended -j ${{ env.CI_NCPU }} --combinedlogslen=99999999 --quiet --timeout-factor=8
 
   freebsd-depends:
     name: 'FreeBSD: depends, MP'
@@ -102,7 +102,7 @@ jobs:
         uses: vmactions/freebsd-vm@v1
         with:
           envs: 'CCACHE_COMPILERCHECK CCACHE_DIR CCACHE_MAXSIZE CCACHE_COMPRESS'
-          prepare: pkg install -y bash curl gmake cmake-core git pkgconf ccache python3 databases/py-sqlite3 net/py-pyzmq
+          prepare: pkg install -y bash curl gmake cmake-core git pkgconf ccache python311 py311-pyzmq py311-sqlite3
           run: git config --global --add safe.directory ${{ github.workspace }}
           sync: 'rsync'
           copyback: false
@@ -147,4 +147,4 @@ jobs:
         if: ${{ ! inputs.skip_functional_tests }}
         run: |
           cd ${{ github.workspace }}
-          ./build/test/functional/test_runner.py --ci --extended -j ${{ env.CI_NCPU }} --combinedlogslen=99999999 --quiet --timeout-factor=8
+          python3.11 ./build/test/functional/test_runner.py --ci --extended -j ${{ env.CI_NCPU }} --combinedlogslen=99999999 --quiet --timeout-factor=8


### PR DESCRIPTION
This change reduces installed dependencies:
```diff
   	pcre2: 10.43
   	perl5: 5.36.3_2
   	pkgconf: 2.3.0,1
-  	py27-setuptools44: 44.1.1_1
-  	py27-sqlite3: 2.7.18_7
-  	py310-setuptools: 63.1.0_1
-  	py310-sqlite3: 3.10.16_7
   	py311-pyzmq: 25.0.2_1
   	py311-setuptools: 63.1.0_1
   	py311-sqlite3: 3.11.11_7
-  	py38-setuptools: 63.1.0_1
-  	py38-sqlite3: 3.8.20_7
-  	py39-setuptools: 63.1.0_1
-  	py39-sqlite3: 3.9.21_7
-  	python27: 2.7.18_3
-  	python3: 3_4
-  	python310: 3.10.16
   	python311: 3.11.11
-  	python38: 3.8.20
-  	python39: 3.9.21
   	readline: 8.2.13_2
   	rhash: 1.4.4_1
   	sqlite3: 3.46.1,1
   
-  Number of packages to be installed: 65
+  Number of packages to be installed: 52
```