### PR TITLE
Windows, UCRT: Install `gawk` package

### DIFF
--- a/.github/workflows/windows-ucrt.yml
+++ b/.github/workflows/windows-ucrt.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          dnf install -y cmake make patch ucrt64-gcc-c++ which
+          dnf install -y cmake make patch ucrt64-gcc-c++ which gawk
 
       - name: Build depends
         run: |


### PR DESCRIPTION
Required to configure the `bdb` package in depends after upgrading the container from Fedora 41 to 42.

Fixes:
```
./config.status: line 1415: awk: command not found
```