### PR TITLE
NetBSD: Drop workaround for linker bug

### DIFF
--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -61,8 +61,7 @@ jobs:
       - name: Generate buildsystem
         run: |
           cd ${{ github.workspace }}
-          # FIXME: The `-Wl,-z,separate-code` flag is incompatible with NetBSD's dynamic linker.
-          cmake -B build -DCMAKE_C_COMPILER="/usr/pkg/gcc14/bin/gcc" -DCMAKE_CXX_COMPILER="/usr/pkg/gcc14/bin/g++" -DWITH_BDB=ON -DWITH_ZMQ=ON -DBUILD_BENCH=ON -DBUILD_FUZZ_BINARY=ON -DWERROR=ON -DAPPEND_LDFLAGS="-Wl,-z,noseparate-code"
+          cmake -B build -DCMAKE_C_COMPILER="/usr/pkg/gcc14/bin/gcc" -DCMAKE_CXX_COMPILER="/usr/pkg/gcc14/bin/g++" -DWITH_BDB=ON -DWITH_ZMQ=ON -DBUILD_BENCH=ON -DBUILD_FUZZ_BINARY=ON -DWERROR=ON
 
       - name: Build
         uses: ./ci/nightly/.github/actions/build-with-ccache
@@ -134,9 +133,7 @@ jobs:
             --toolchain depends/$(./depends/config.sub $(./depends/config.guess))/toolchain.cmake \
             -DBUILD_BENCH=ON \
             -DBUILD_FUZZ_BINARY=ON \
-            -DWERROR=ON \
-            `# FIXME: The -Wl,-z,separate-code flag is incompatible with NetBSD's dynamic linker.` \
-            -DAPPEND_LDFLAGS="-Wl,-z,noseparate-code"
+            -DWERROR=ON
 
       - name: Build
         uses: ./ci/nightly/.github/actions/build-with-ccache


### PR DESCRIPTION
This workaround is no longer necessary, as https://github.com/bitcoin/bitcoin/pull/32071 has been merged.