### PR TITLE
Windows, MSVC: Drop workaround for stack overflow

### DIFF
--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -39,10 +39,6 @@ jobs:
           Write-Host "PowerShell version $($PSVersionTable.PSVersion.ToString())"
 
       - name: Generate buildsystem
-        env:
-          # Increase stack size to accommodate the deep recursion
-          # in the FindChallenges() function used in miniscript_tests.
-          LDFLAGS: '/STACK:2097152'
         run: |
           cmake -B build --preset vs2022 -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT\scripts\buildsystems\vcpkg.cmake" -DBUILD_GUI=ON -DWITH_BDB=ON -DWITH_ZMQ=ON -DBUILD_BENCH=ON -DWERROR=ON
 


### PR DESCRIPTION
This workaround is no longer necessary, as https://github.com/bitcoin/bitcoin/pull/32351 has been merged.