### PR TITLE
OpenBSD: Enable `MULTIPROCESS=1` in depends

### DIFF
--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -85,7 +85,7 @@ jobs:
           ./build/test/functional/test_runner.py --ci --extended -j ${{ env.CI_NCPU }} --combinedlogslen=99999999 --quiet --tmpdirprefix . --timeout-factor=8
 
   openbsd-depends:
-    name: 'OpenBSD: depends, no MP'
+    name: 'OpenBSD: depends, MP'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -116,8 +116,7 @@ jobs:
         uses: ./ci/nightly/.github/actions/build-depends
         with:
           vm: openbsd
-          # TODO: Fix capnp compilation and enable MULTIPROCESS.
-          # options: "MULTIPROCESS=1"
+          options: "MULTIPROCESS=1"
 
       - name: Generate buildsystem
         run: >

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ For another repository with nightly builds of Bitcoin Core, see [maflcko/b-c-nig
 | Operating System | Status | Build with System Libs | Build with Depends |
 |------------------|--------|------------------------|--------------------|
 | [FreeBSD](https://www.freebsd.org/) | [![FreeBSD](https://github.com/hebasto/bitcoin-core-nightly/actions/workflows/freebsd.yml/badge.svg)](https://github.com/hebasto/bitcoin-core-nightly/actions/workflows/freebsd.yml?query=event%3Aschedule) | Qt - not installed <br> USDT - N/A | 1. Release, `MULTIPROCESS=1` |
-| [OpenBSD](https://www.openbsd.org/) | [![OpenBSD](https://github.com/hebasto/bitcoin-core-nightly/actions/workflows/openbsd.yml/badge.svg)](https://github.com/hebasto/bitcoin-core-nightly/actions/workflows/openbsd.yml?query=event%3Aschedule) | Qt - not installed <br> USDT - N/A | 1. Release <br> --- <br> See MP-related [issue](https://github.com/capnproto/capnproto/pull/1907) |
+| [OpenBSD](https://www.openbsd.org/) | [![OpenBSD](https://github.com/hebasto/bitcoin-core-nightly/actions/workflows/openbsd.yml/badge.svg)](https://github.com/hebasto/bitcoin-core-nightly/actions/workflows/openbsd.yml?query=event%3Aschedule) | Qt - not installed <br> USDT - N/A | 1. Release, `MULTIPROCESS=1` |
 | [NetBSD](https://netbsd.org/) | [![NetBSD](https://github.com/hebasto/bitcoin-core-nightly/actions/workflows/netbsd.yml/badge.svg)](https://github.com/hebasto/bitcoin-core-nightly/actions/workflows/netbsd.yml?query=event%3Aschedule) | Qt - not installed <br> USDT - N/A | 1. Release, `MULTIPROCESS=1` |
 
 ## [illumos](https://illumos.org/)-Based Systems


### PR DESCRIPTION
The code has been patched in https://github.com/bitcoin/bitcoin/pull/32690.