### PR TITLE
NetBSD: Switch to `boost` package

### DIFF
--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -45,7 +45,7 @@ jobs:
           envs: 'CCACHE_COMPILERCHECK CCACHE_DIR CCACHE_MAXSIZE'
           prepare: |
             /usr/sbin/pkg_info > packages_before
-            /usr/sbin/pkg_add cmake git-base gcc14 pkg-config ccache boost-headers libevent sqlite3 zeromq python313 py313-zmq
+            /usr/sbin/pkg_add cmake git-base gcc14 pkg-config ccache boost libevent sqlite3 zeromq python313 py313-zmq
             /usr/sbin/pkg_info > packages_after
             diff -w packages_before packages_after | grep '^>'
           run: git config --global --add safe.directory ${{ github.workspace }}


### PR DESCRIPTION
The `boost-headers` package does not provide CMake configuration files required since https://github.com/bitcoin/bitcoin/pull/32667.