### PR TITLE
Windows: Delete "Run rpcauth tests" step

### DIFF
--- a/.github/workflows/windows-ucrt.yml
+++ b/.github/workflows/windows-ucrt.yml
@@ -110,9 +110,6 @@ jobs:
           (Get-Content "test\config.ini") -replace '(?<=^SRCDIR=).*', '${{ github.workspace }}' -replace '(?<=^BUILDDIR=).*', '${{ github.workspace }}' -replace '(?<=^RPCAUTH=).*', '${{ github.workspace }}\share\rpcauth\rpcauth.py' | Set-Content "test\config.ini"
           Get-Content "test\config.ini"
 
-      - name: Run rpcauth test
-        run: py -3 test\util\rpcauth-test.py
-
       - name: Run functional tests
         if: ${{ ! inputs.skip_functional_tests }}
         env:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -107,9 +107,6 @@ jobs:
           (Get-Content "test\config.ini") -replace '(?<=^SRCDIR=).*', '${{ github.workspace }}' -replace '(?<=^BUILDDIR=).*', '${{ github.workspace }}' -replace '(?<=^RPCAUTH=).*', '${{ github.workspace }}\share\rpcauth\rpcauth.py' | Set-Content "test\config.ini"
           Get-Content "test\config.ini"
 
-      - name: Run rpcauth test
-        run: py -3 test\util\rpcauth-test.py
-
       - name: Run functional tests
         env:
           # TODO: Fix the excluded test and re-enable it.


### PR DESCRIPTION
Required since https://github.com/bitcoin/bitcoin/pull/32881.