### PR TITLE
Alpine: Avoid build failure from `-Wstringop-overflow=` warning

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -28,9 +28,11 @@ jobs:
       matrix:
         configuration:
           - name: ''
+            # See: https://github.com/bitcoin/bitcoin/pull/31829#discussion_r2217735632.
+            config-options: -DAPPEND_CXXFLAGS="-Wno-error=stringop-overflow"
           - name: ', debug'
             depends-options: DEBUG=1
-            config-options: -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS=-Wno-error=maybe-uninitialized
+            config-options: -DCMAKE_BUILD_TYPE=Debug -DAPPEND_CXXFLAGS="-Wno-error=maybe-uninitialized"
 
     steps:
       - name: Checkout Bitcoin Core repo


### PR DESCRIPTION
Required since https://github.com/bitcoin/bitcoin/pull/31829.