### PR TITLE
OmniOS: Temporarily disable IPC in "system libs" job

### DIFF
--- a/.github/workflows/omnios.yml
+++ b/.github/workflows/omnios.yml
@@ -82,7 +82,8 @@ jobs:
           # Workaround for a bug in the FindThreads module.
           # See: https://gitlab.kitware.com/cmake/cmake/-/issues/26063
           export CXXFLAGS="-pthread"
-          cmake -B build -DBUILD_BENCH=ON -DBUILD_FUZZ_BINARY=ON -DWERROR=ON
+          # TODO: Build Cap'n Proto from source and reenable IPC.
+          cmake -B build -DENABLE_IPC=OFF -DBUILD_BENCH=ON -DBUILD_FUZZ_BINARY=ON -DWERROR=ON
 
       - name: Build
         uses: ./ci/nightly/.github/actions/build-with-ccache


### PR DESCRIPTION
Required since bitcoin/bitcoin#31802 was merged.