### PR TITLE
Windows, LLVM: Update LLVM MinGW toolchain

### DIFF
--- a/.github/workflows/windows-llvm-arm64.yml
+++ b/.github/workflows/windows-llvm-arm64.yml
@@ -19,8 +19,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CI_LLVM_MINGW_URL: https://github.com/mstorsjo/llvm-mingw/releases/download/20251104/llvm-mingw-20251104-ucrt-ubuntu-22.04-x86_64.tar.xz
-  CI_LLVM_MINGW_HASH: 3aed6fa47be909884cb3e5634d6b7254604d7104832d6312f8435fb23d5a9bab
+  CI_LLVM_MINGW_URL: https://github.com/mstorsjo/llvm-mingw/releases/download/20251118/llvm-mingw-20251118-ucrt-ubuntu-22.04-x86_64.tar.xz
+  CI_LLVM_MINGW_HASH: 53a0c22caa46b501e1c089e1c31b24a7c0e0d5a86f8ad12b131aafd4cee01ef4
 
 jobs:
   windows-aarch64-cross:

--- a/.github/workflows/windows-llvm-x86_64.yml
+++ b/.github/workflows/windows-llvm-x86_64.yml
@@ -19,8 +19,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CI_LLVM_MINGW_URL: https://github.com/mstorsjo/llvm-mingw/releases/download/20251104/llvm-mingw-20251104-ucrt-ubuntu-22.04-x86_64.tar.xz
-  CI_LLVM_MINGW_HASH: 3aed6fa47be909884cb3e5634d6b7254604d7104832d6312f8435fb23d5a9bab
+  CI_LLVM_MINGW_URL: https://github.com/mstorsjo/llvm-mingw/releases/download/20251118/llvm-mingw-20251118-ucrt-ubuntu-22.04-x86_64.tar.xz
+  CI_LLVM_MINGW_HASH: 53a0c22caa46b501e1c089e1c31b24a7c0e0d5a86f8ad12b131aafd4cee01ef4
 
 jobs:
   windows-x86_64-cross:


### PR DESCRIPTION
Update to ["llvm-mingw 20251118 with LLVM 21.1.6"](https://github.com/mstorsjo/llvm-mingw/releases/tag/20251118).