### PR TITLE
FreeBSD: Remove `--quiet` option from functional tests

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -85,7 +85,7 @@ jobs:
         if: ${{ ! inputs.skip_functional_tests }}
         run: |
           cd ${{ github.workspace }}
-          ./build/test/functional/test_runner.py --ci --extended -j ${{ env.CI_NCPU }} --combinedlogslen=99999999 --quiet --timeout-factor=8
+          ./build/test/functional/test_runner.py --ci --extended -j ${{ env.CI_NCPU }} --combinedlogslen=99999999 --timeout-factor=8
 
   freebsd-depends:
     name: 'FreeBSD: depends, MP'


### PR DESCRIPTION
This is intended to aid debugging of the recent issue in the functional tests.