### PR TITLE
Windows, UCRT: Add `-Wno-error=deprecated-declarations`

### DIFF
--- a/.github/workflows/windows-gcc-ucrt.yml
+++ b/.github/workflows/windows-gcc-ucrt.yml
@@ -50,7 +50,7 @@ jobs:
             -DBUILD_FUZZ_BINARY=ON \
             -DWERROR=ON \
             `# TODO: Drop -Wno-error=deprecated-declarations once https://github.com/bitcoin/bitcoin/issues/32361 is fixed.` \
-            -DAPPEND_CXXFLAGS='-Wno-error=maybe-uninitialized -Wno-error=array-bounds -Wno-error=deprecated-declarations'
+            -DAPPEND_CXXFLAGS='-Wno-error=array-bounds -Wno-error=deprecated-declarations'
 
       - name: Build
         run: cmake --build build -j $(nproc)


### PR DESCRIPTION
This change is required because the Fedora image has been updated to version 43, which ships `ucrt64-gcc-c++` 15.2.1.