### PR TITLE
Revert "Windows, UCRT: Install `tcl` on Fedora image"

### DIFF
--- a/.github/workflows/windows-gcc-ucrt.yml
+++ b/.github/workflows/windows-gcc-ucrt.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          dnf install -y cmake make patch ucrt64-gcc-c++ which gawk gcc tcl
+          dnf install -y cmake make patch ucrt64-gcc-c++ which gawk gcc
 
       - name: Build depends
         run: |


### PR DESCRIPTION
This reverts commit bccf22d92ff3cc4c69a3b0ae2cd583af3fdb1abf.

The `tcl` package has not been necessary since bitcoin/bitcoin#33995.