### PR TITLE
NetBSD: Set `TMPDIR` for tests

### DIFF
--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -100,6 +100,7 @@ jobs:
         uses: ./ci/nightly/.github/actions/run-test-suite
         with:
           vm: netbsd
+          envs: 'TMPDIR="${{ github.workspace }}"'
 
       - &RUN_FUNCTIONAL_TESTS
         name: Run functional tests


### PR DESCRIPTION
This aims to avoid SEGFAULT in benchmarks.