### PR TITLE
FreeBSD: Add temporary workaround for FreeBSD 15.0

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -125,6 +125,8 @@ jobs:
         uses: ./ci/nightly/.github/actions/build-depends
         with:
           vm: freebsd
+          # TODO: Fix a linking error.
+          options: "NO_QT=1"
 
       - name: Generate buildsystem
         env:


### PR DESCRIPTION
This workaround will be dropped once https://github.com/bitcoin/bitcoin/pull/34093 is merged.