### PR TITLE
FreeBSD: Add 'lsof' package to preparation steps in workflow

### DIFF
--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -55,8 +55,9 @@ jobs:
           release: ${{ matrix.release }}
           mem: 12288
           prepare: |
+            echo "CHECK_OSABI=no" >> /etc/pkg_install.conf
             pkg_info > packages_before
-            pkg_add -u cmake curl gcc14 git-base ninja-build pkgconf py313-zmq python313 ${{ env.PACKAGES }}
+            pkg_add -u cmake curl gcc14 git-base lsof ninja-build pkgconf py313-zmq python313 ${{ env.PACKAGES }}
             pkg_info > packages_after
             diff -w packages_before packages_after | grep '^>'
           sync: 'rsync'

--- a/.github/workflows/omnios.yml
+++ b/.github/workflows/omnios.yml
@@ -48,7 +48,7 @@ jobs:
           prepare: |
             set -e
             pkg list -H -o name,publisher,version > packages_before
-            pkg install cmake ninja git gcc14 pkg-config sqlite-3 python-313
+            pkg install cmake ninja git gcc14 ooce/file/lsof pkg-config sqlite-3 python-313
             pkg set-publisher -g https://sfe.opencsw.org/localhostomnios localhostomnios
             pkg install libevent2
             pkg list -H -o name,publisher,version > packages_after

--- a/.github/workflows/omnios.yml
+++ b/.github/workflows/omnios.yml
@@ -117,4 +117,7 @@ jobs:
             --extended \
             `# See https://github.com/bitcoin/bitcoin/issues/33128.` \
             --exclude feature_reindex_init \
+            `# TODO https://github.com/bitcoin/bitcoin/pull/35216` \
+            --exclude feature_bind_extra \
+            --exclude rpc_bind \
             --timeout-factor=8

--- a/.github/workflows/openindiana.yml
+++ b/.github/workflows/openindiana.yml
@@ -59,6 +59,7 @@ jobs:
             set -e
             pkg list > packages_before
             pkg install developer/build/pkgconf
+            pkg install system/storage/lsof
             pkg install library/c++/zeromq
             pkg list > packages_after
             diff -w packages_before packages_after | grep '^>' || true

--- a/.github/workflows/openindiana.yml
+++ b/.github/workflows/openindiana.yml
@@ -153,4 +153,7 @@ jobs:
             --exclude feature_reindex_init \
             `# TODO: Investigate the failure.` \
             --exclude interface_bitcoin_cli \
+            `# TODO https://github.com/bitcoin/bitcoin/pull/35216` \
+            --exclude feature_bind_extra \
+            --exclude rpc_bind \
             --timeout-factor=8


### PR DESCRIPTION
This will be needed to be able to run https://github.com/bitcoin/bitcoin/pull/34256