### PR TITLE
Windows, LLVM: Update LLVM MinGW toolchain

### DIFF
--- a/.github/workflows/windows-llvm-arm64.yml
+++ b/.github/workflows/windows-llvm-arm64.yml
@@ -20,8 +20,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CI_LLVM_MINGW_URL: https://github.com/mstorsjo/llvm-mingw/releases/download/20260324/llvm-mingw-20260324-ucrt-ubuntu-22.04-x86_64.tar.xz
-  CI_LLVM_MINGW_HASH: f92b02c4f835470deb5ac5fb92ddb458239e80ddff9ce8867155679ee5f57ffc
+  CI_LLVM_MINGW_URL: https://github.com/mstorsjo/llvm-mingw/releases/download/20260407/llvm-mingw-20260407-ucrt-ubuntu-22.04-x86_64.tar.xz
+  CI_LLVM_MINGW_HASH: c39aeb4823bbc89ce2a40820964a114614a524c2cb7be1e3dafd16f780fa39b1
   CI_HOST: aarch64-w64-mingw32
 
 jobs:

--- a/.github/workflows/windows-llvm-x86_64.yml
+++ b/.github/workflows/windows-llvm-x86_64.yml
@@ -20,8 +20,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CI_LLVM_MINGW_URL: https://github.com/mstorsjo/llvm-mingw/releases/download/20260324/llvm-mingw-20260324-ucrt-ubuntu-22.04-x86_64.tar.xz
-  CI_LLVM_MINGW_HASH: f92b02c4f835470deb5ac5fb92ddb458239e80ddff9ce8867155679ee5f57ffc
+  CI_LLVM_MINGW_URL: https://github.com/mstorsjo/llvm-mingw/releases/download/20260407/llvm-mingw-20260407-ucrt-ubuntu-22.04-x86_64.tar.xz
+  CI_LLVM_MINGW_HASH: c39aeb4823bbc89ce2a40820964a114614a524c2cb7be1e3dafd16f780fa39b1
   CI_HOST: x86_64-w64-mingw32
 
 jobs:


### PR DESCRIPTION
Update to ["llvm-mingw 20260407 with LLVM 22.1.3"](https://github.com/mstorsjo/llvm-mingw/releases/tag/20260407).