### PR TITLE
NetBSD: Drop support for NetBSD 9.x

### DIFF
--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -39,10 +39,6 @@ jobs:
         # Test all supported releases.
         # See https://www.netbsd.org/releases/.
         include:
-          - release: '9.4'
-            capnproto-cppflags: '-DKJ_USE_KQUEUE=0'
-            zeromq-cppflags: '-DZMQ_NETBSD_KEVENT_UDATA_INTPTR_T=1'
-            packages: 'mozilla-rootcerts-openssl'
           - release: '10.1'
 
     steps:
@@ -60,7 +56,7 @@ jobs:
           mem: 12288
           prepare: |
             pkg_info > packages_before
-            pkg_add -u cmake curl gcc14 git-base ninja-build pkgconf py313-zmq python313 ${{ matrix.packages }} ${{ env.PACKAGES }}
+            pkg_add -u cmake curl gcc14 git-base ninja-build pkgconf py313-zmq python313 ${{ env.PACKAGES }}
             pkg_info > packages_after
             diff -w packages_before packages_after | grep '^>'
           sync: 'rsync'
@@ -87,7 +83,7 @@ jobs:
             pkgsrc/sysutils/install-sh/files
           cd /usr/pkgsrc/devel/capnproto
           unset PKG_PATH
-          make CPPFLAGS="-DKJ_NO_EXCEPTIONS=0 ${{ matrix.capnproto-cppflags }}" install
+          make CPPFLAGS="-DKJ_NO_EXCEPTIONS=0" install
 
       - name: Generate buildsystem
         run: |
@@ -170,9 +166,6 @@ jobs:
             build_CXX=/usr/pkg/gcc14/bin/g++
             CC=/usr/pkg/gcc14/bin/gcc
             CXX=/usr/pkg/gcc14/bin/g++
-            native_capnp_cppflags_netbsd=${{ matrix.capnproto-cppflags }}
-            capnp_cppflags_netbsd=${{ matrix.capnproto-cppflags }}
-            zeromq_cppflags_netbsd=${{ matrix.zeromq-cppflags }}
           cache-tag: netbsd-${{ matrix.release }}
 
       - name: Generate buildsystem

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For another repository with nightly builds of Bitcoin Core, see [maflcko/b-c-nig
 |------------------|:--------:|--------|------------------------|--------------------|
 | [FreeBSD](https://www.freebsd.org/) | 14.4, 15.0 | [![FreeBSD](https://github.com/hebasto/bitcoin-core-nightly/actions/workflows/freebsd.yml/badge.svg)](https://github.com/hebasto/bitcoin-core-nightly/actions/workflows/freebsd.yml?query=event%3Aworkflow_run) | Qt - not installed <br> USDT - N/A | Release |
 | [OpenBSD](https://www.openbsd.org/) | 7.8 | [![OpenBSD](https://github.com/hebasto/bitcoin-core-nightly/actions/workflows/openbsd.yml/badge.svg)](https://github.com/hebasto/bitcoin-core-nightly/actions/workflows/openbsd.yml?query=event%3Aworkflow_run) | Qt - not installed <br> USDT - N/A | Release |
-| [NetBSD](https://netbsd.org/) | 9.4, 10.1 | [![NetBSD](https://github.com/hebasto/bitcoin-core-nightly/actions/workflows/netbsd.yml/badge.svg)](https://github.com/hebasto/bitcoin-core-nightly/actions/workflows/netbsd.yml?query=event%3Aworkflow_run) | Qt - not installed <br> USDT - N/A | Release |
+| [NetBSD](https://netbsd.org/) | 10.1 | [![NetBSD](https://github.com/hebasto/bitcoin-core-nightly/actions/workflows/netbsd.yml/badge.svg)](https://github.com/hebasto/bitcoin-core-nightly/actions/workflows/netbsd.yml?query=event%3Aworkflow_run) | Qt - not installed <br> USDT - N/A | Release |
 
 ## [illumos](https://illumos.org/)-Based Systems
 


### PR DESCRIPTION
With NetBSD 11 approaching, it is reasonable to drop support for 9.x. Currently, the 9.4 package repository is still linked to [`2025Q4`](https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/x86_64/9.0_2025Q4/) rather than [`2026Q1`](https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/x86_64/9.0_2026Q1/).