### PR TITLE
OpenIndiana: Temporarily disable `coins_tests_base` test

### DIFF
--- a/.github/workflows/openindiana.yml
+++ b/.github/workflows/openindiana.yml
@@ -127,7 +127,9 @@ jobs:
           export DIR_UNIT_TEST_DATA="${{ github.workspace }}/qa-assets/unit_test_data"
           mkdir -p ${DIR_UNIT_TEST_DATA}
           curl --location --fail --output "${DIR_UNIT_TEST_DATA}/script_assets_test.json" https://github.com/bitcoin-core/qa-assets/raw/main/unit_test_data/script_assets_test.json
-          ctest --test-dir build -j ${{ env.CI_NCPU }} --output-on-failure
+          ctest --test-dir build -j ${{ env.CI_NCPU }} --output-on-failure \
+            `# TODO: Investigate libc thread failure in coins_tests_base.` \
+            -E '^coins_tests_base$'
 
       - name: Install Python packages for functional tests
         if: ${{ ! inputs.skip_functional_tests }}


### PR DESCRIPTION
The recent OS image [update](https://github.com/vmactions/openindiana-vm/releases/tag/v1.0.9) causes a libc thread [failure](https://github.com/hebasto/bitcoin-core-nightly/actions/runs/25244645997/job/74026671161):
```
*** libc thread failure: lfree() called with a misaligned pointer
```

The build still passes locally on OpenIndiana 5.11 (`illumos-f6389fcb2f`).