### PR TITLE
Windows, LLVM: Update LLVM MinGW toolchain

### DIFF
--- a/.github/workflows/windows-llvm-arm64.yml
+++ b/.github/workflows/windows-llvm-arm64.yml
@@ -20,8 +20,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CI_LLVM_MINGW_URL: https://github.com/mstorsjo/llvm-mingw/releases/download/20260421/llvm-mingw-20260421-ucrt-ubuntu-22.04-x86_64.tar.xz
-  CI_LLVM_MINGW_HASH: f8b8cce779affeab47bcaec6ce6e9e768b166094a366123ef64b2d0b389cc121
+  CI_LLVM_MINGW_URL: https://github.com/mstorsjo/llvm-mingw/releases/download/20260505/llvm-mingw-20260505-ucrt-ubuntu-22.04-x86_64.tar.xz
+  CI_LLVM_MINGW_HASH: 986d7beef2f6d7e2f3939a1d04ac8746d614e7014557961e7e0d381d7bc5fdcd
   CI_HOST: aarch64-w64-mingw32
 
 jobs:

--- a/.github/workflows/windows-llvm-x86_64.yml
+++ b/.github/workflows/windows-llvm-x86_64.yml
@@ -20,8 +20,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CI_LLVM_MINGW_URL: https://github.com/mstorsjo/llvm-mingw/releases/download/20260421/llvm-mingw-20260421-ucrt-ubuntu-22.04-x86_64.tar.xz
-  CI_LLVM_MINGW_HASH: f8b8cce779affeab47bcaec6ce6e9e768b166094a366123ef64b2d0b389cc121
+  CI_LLVM_MINGW_URL: https://github.com/mstorsjo/llvm-mingw/releases/download/20260505/llvm-mingw-20260505-ucrt-ubuntu-22.04-x86_64.tar.xz
+  CI_LLVM_MINGW_HASH: 986d7beef2f6d7e2f3939a1d04ac8746d614e7014557961e7e0d381d7bc5fdcd
   CI_HOST: x86_64-w64-mingw32
 
 jobs:


### PR DESCRIPTION
Update to ["llvm-mingw 20260505 with LLVM 22.1.5"](https://github.com/mstorsjo/llvm-mingw/releases/tag/20260505).