### PR TITLE
Revert "FreeBSD: Temporarily disable building GUI on FreeBSD 15.0"

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -147,8 +147,6 @@ jobs:
         uses: ./ci/nightly/.github/actions/build-depends
         with:
           vm: freebsd
-          # TODO: Fix a linking error.
-          options: "NO_QT=1"
           source-dir: /root/bitcoin
           cache-tag: freebsd-${{ matrix.release }}
 


### PR DESCRIPTION
This reverts commit f0a4974639688b03fdb671abc807c341927f5b68 from https://github.com/hebasto/bitcoin-core-nightly/pull/121.