### PR TITLE
FreeBSD: Mitigate test failures from intermittent `lsof` warnings

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -116,10 +116,18 @@ jobs:
         name: Run functional tests
         if: ${{ ! inputs.skip_functional_tests }}
         run: |
+          set -e
           build/test/functional/test_runner.py -j $((${{ env.CI_NCPU }} * 2)) --combinedlogslen=99999999 \
             --extended \
             `# See https://github.com/bitcoin/bitcoin/issues/33128.` \
             --exclude feature_reindex_init \
+            `# Tests using lsof may fail due to the following warning:` \
+            `# lsof: WARNING -- reading lockf list failed: Cannot allocate memory` \
+            `# Run them separately in the subsequent command.` \
+            --exclude feature_bind_extra \
+            --exclude rpc_bind \
+            --timeout-factor=8
+          build/test/functional/test_runner.py feature_bind_extra rpc_bind -j 1 --combinedlogslen=99999999 \
             --timeout-factor=8
 
   freebsd-depends:


### PR DESCRIPTION
https://github.com/hebasto/bitcoin-core-nightly/actions/runs/25653396553/job/75296286184:
```
213/461 - rpc_bind.py --ipv6 failed, Duration: 4 s

stdout:
2026-05-11T06:52:51.471168Z TestFramework (INFO): PRNG seed is: 7662909891472230539
2026-05-11T06:52:51.472199Z TestFramework (INFO): Initializing test directory /tmp/test_runner_₿_🏃_20260511_064806/rpc_bind_244
2026-05-11T06:52:51.473206Z TestFramework (INFO): Check for ipv6
2026-05-11T06:52:51.473408Z TestFramework (INFO): Check for non-loopback interface
2026-05-11T06:52:51.487981Z TestFramework (INFO): Bind test for []
2026-05-11T06:52:51.968314Z TestFramework (INFO): Bind test for []
2026-05-11T06:52:52.389734Z TestFramework (INFO): Bind test for ['[::1]']
2026-05-11T06:52:52.966594Z TestFramework (INFO): Bind test for ['127.0.0.1', '[::1]']
2026-05-11T06:52:53.585819Z TestFramework (INFO): Invalid bind test for ['[::1]:notaport', '[::1]:-18443', '[::1]:0', '[::1]:65536']
2026-05-11T06:52:54.275574Z TestFramework (INFO): Allow RFC4193 when compatible with CJDNS options
2026-05-11T06:52:55.679834Z TestFramework (INFO): Stopping nodes
2026-05-11T06:52:55.680672Z TestFramework (INFO): Cleaning up /tmp/test_runner_₿_🏃_20260511_064806/rpc_bind_244 on exit
2026-05-11T06:52:55.681216Z TestFramework (INFO): Tests successful


stderr:
lsof: WARNING -- reading lockf list failed: Cannot allocate memory


```

https://github.com/hebasto/bitcoin-core-nightly/actions/runs/25844523070/job/75936721173:
```
248/461 - feature_bind_extra.py failed, Duration: 2 s

stdout:
2026-05-14T06:59:07.362854Z TestFramework (INFO): PRNG seed is: 5927913460016243617
2026-05-14T06:59:07.416306Z TestFramework (INFO): Initializing test directory /tmp/test_runner_₿_🏃_20260514_065342/feature_bind_extra_208
2026-05-14T06:59:07.720196Z TestFramework (INFO): Checking listening ports of node 0 with ['-bind=127.0.0.1:13499=onion']
2026-05-14T06:59:07.730076Z TestFramework (INFO): Checking listening ports of node 1 with ['-bind=127.0.0.1:13500', '-bind=127.0.0.1:13501=onion']
2026-05-14T06:59:07.735927Z TestFramework (INFO): Checking listening ports of node 2 with ['-bind=127.0.0.1:13502']
2026-05-14T06:59:09.273906Z TestFramework (INFO): Stopping nodes
2026-05-14T06:59:09.436554Z TestFramework (INFO): Cleaning up /tmp/test_runner_₿_🏃_20260514_065342/feature_bind_extra_208 on exit
2026-05-14T06:59:09.436650Z TestFramework (INFO): Tests successful


stderr:
lsof: WARNING -- reading lockf list failed: Cannot allocate memory


```