### PR TITLE
Windows, LLVM: Update LLVM MinGW toolchain

### DIFF
--- a/.github/workflows/windows-llvm-arm64.yml
+++ b/.github/workflows/windows-llvm-arm64.yml
@@ -20,8 +20,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CI_LLVM_MINGW_URL: https://github.com/mstorsjo/llvm-mingw/releases/download/20260505/llvm-mingw-20260505-ucrt-ubuntu-22.04-x86_64.tar.xz
-  CI_LLVM_MINGW_HASH: 986d7beef2f6d7e2f3939a1d04ac8746d614e7014557961e7e0d381d7bc5fdcd
+  CI_LLVM_MINGW_URL: https://github.com/mstorsjo/llvm-mingw/releases/download/20260519/llvm-mingw-20260519-ucrt-ubuntu-22.04-x86_64.tar.xz
+  CI_LLVM_MINGW_HASH: a48f8c2801508272ccde64d87a26747ecc5306623d9a080a42ed80dc61f79fa2
   CI_HOST: aarch64-w64-mingw32
 
 jobs:

--- a/.github/workflows/windows-llvm-arm64.yml
+++ b/.github/workflows/windows-llvm-arm64.yml
@@ -88,15 +88,13 @@ jobs:
         with:
           name: ${{ env.CI_HOST }}-executables-${{ github.run_id }}
 
-      - name: Configure Developer Command Prompt for Microsoft Visual C++
-        uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: arm64
-
       - name: Check 'bitcoind.exe' executable
+        # https://learn.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=msvc-180#developer_command_file_locations
+        shell: cmd
         run: |
-          dumpbin.exe /imports bin\bitcoind.exe | Select-String -Pattern "\S+\.dll" -CaseSensitive:$false
-          bin\bitcoind.exe -version
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=arm64 -host_arch=arm64 -no_logo
+          pwsh.exe -Command "dumpbin.exe /imports bin\bitcoind.exe | Select-String -Pattern '\S+\.dll' -CaseSensitive:$false" || exit 1
+          bin\bitcoind.exe -version || exit 1
 
       - name: Run unit tests
         run: |

--- a/.github/workflows/windows-llvm-arm64.yml
+++ b/.github/workflows/windows-llvm-arm64.yml
@@ -55,7 +55,7 @@ jobs:
             -DBUILD_BENCH=ON \
             -DBUILD_FUZZ_BINARY=ON \
             -DCMAKE_COMPILE_WARNING_AS_ERROR=ON \
-            -DAPPEND_CXXFLAGS="-Wno-error=deprecated-declarations -Wno-error=unused-member-function -Wno-error=unused-private-field"
+            -DAPPEND_CXXFLAGS="-Wno-error=deprecated-declarations"
 
       - name: Build
         run: cmake --build build -j $(nproc)

--- a/.github/workflows/windows-llvm-x86_64.yml
+++ b/.github/workflows/windows-llvm-x86_64.yml
@@ -71,7 +71,7 @@ jobs:
 
   windows-x86_64-native-test:
     name: 'Windows x86-64, test cross-built executables natively'
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     needs: windows-x86_64-cross
     defaults:
       run:
@@ -88,15 +88,13 @@ jobs:
         with:
           name: ${{ env.CI_HOST }}-executables-${{ github.run_id }}
 
-      - name: Configure Developer Command Prompt for Microsoft Visual C++
-        uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: x64
-
       - name: Check 'bitcoind.exe' executable
+        # https://learn.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=msvc-180#developer_command_file_locations
+        shell: cmd
         run: |
-          dumpbin.exe /imports bin\bitcoind.exe | Select-String -Pattern "\S+\.dll" -CaseSensitive:$false
-          bin\bitcoind.exe -version
+          call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=amd64 -host_arch=amd64 -no_logo
+          pwsh.exe -Command "dumpbin.exe /imports bin\bitcoind.exe | Select-String -Pattern '\S+\.dll' -CaseSensitive:$false" || exit 1
+          bin\bitcoind.exe -version || exit 1
 
       - name: Run unit tests
         run: |

--- a/.github/workflows/windows-llvm-x86_64.yml
+++ b/.github/workflows/windows-llvm-x86_64.yml
@@ -20,8 +20,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CI_LLVM_MINGW_URL: https://github.com/mstorsjo/llvm-mingw/releases/download/20260505/llvm-mingw-20260505-ucrt-ubuntu-22.04-x86_64.tar.xz
-  CI_LLVM_MINGW_HASH: 986d7beef2f6d7e2f3939a1d04ac8746d614e7014557961e7e0d381d7bc5fdcd
+  CI_LLVM_MINGW_URL: https://github.com/mstorsjo/llvm-mingw/releases/download/20260519/llvm-mingw-20260519-ucrt-ubuntu-22.04-x86_64.tar.xz
+  CI_LLVM_MINGW_HASH: a48f8c2801508272ccde64d87a26747ecc5306623d9a080a42ed80dc61f79fa2
   CI_HOST: x86_64-w64-mingw32
 
 jobs:

--- a/.github/workflows/windows-llvm-x86_64.yml
+++ b/.github/workflows/windows-llvm-x86_64.yml
@@ -55,7 +55,7 @@ jobs:
             -DBUILD_BENCH=ON \
             -DBUILD_FUZZ_BINARY=ON \
             -DCMAKE_COMPILE_WARNING_AS_ERROR=ON \
-            -DAPPEND_CXXFLAGS="-Wno-error=deprecated-declarations -Wno-error=unused-member-function -Wno-error=unused-private-field"
+            -DAPPEND_CXXFLAGS="-Wno-error=deprecated-declarations"
 
       - name: Build
         run: cmake --build build -j $(nproc)


### PR DESCRIPTION
Update to ["llvm-mingw 20260519 with LLVM 22.1.6"](https://github.com/mstorsjo/llvm-mingw/releases/tag/20260519).

Additional changes:
1. Dropped unneeded `-Wno-error=*` flags:
 - `-Wno-error=unused-private-field` -- https://github.com/bitcoin/bitcoin/pull/34385
 - `-Wno-error=unused-member-function` -- https://github.com/bitcoin-core/leveldb-subtree/pull/53,  https://github.com/bitcoin/bitcoin/pull/35313

2. Removed the outdated `msvc-dev-cmd` action.