### PR TITLE
Windows, LLVM: Update LLVM MinGW toolchain

### DIFF
--- a/.github/workflows/windows-llvm-arm64.yml
+++ b/.github/workflows/windows-llvm-arm64.yml
@@ -20,8 +20,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CI_LLVM_MINGW_URL: https://github.com/mstorsjo/llvm-mingw/releases/download/20260519/llvm-mingw-20260519-ucrt-ubuntu-22.04-x86_64.tar.xz
-  CI_LLVM_MINGW_HASH: a48f8c2801508272ccde64d87a26747ecc5306623d9a080a42ed80dc61f79fa2
+  CI_LLVM_MINGW_URL: https://github.com/mstorsjo/llvm-mingw/releases/download/20260602/llvm-mingw-20260602-ucrt-ubuntu-22.04-x86_64.tar.xz
+  CI_LLVM_MINGW_HASH: 9d191203f9768ead60662d3ae53cdf28e0a28b1e6d44b7f329b9202cb2add337
   CI_HOST: aarch64-w64-mingw32
 
 jobs:

--- a/.github/workflows/windows-llvm-x86_64.yml
+++ b/.github/workflows/windows-llvm-x86_64.yml
@@ -20,8 +20,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CI_LLVM_MINGW_URL: https://github.com/mstorsjo/llvm-mingw/releases/download/20260519/llvm-mingw-20260519-ucrt-ubuntu-22.04-x86_64.tar.xz
-  CI_LLVM_MINGW_HASH: a48f8c2801508272ccde64d87a26747ecc5306623d9a080a42ed80dc61f79fa2
+  CI_LLVM_MINGW_URL: https://github.com/mstorsjo/llvm-mingw/releases/download/20260602/llvm-mingw-20260602-ucrt-ubuntu-22.04-x86_64.tar.xz
+  CI_LLVM_MINGW_HASH: 9d191203f9768ead60662d3ae53cdf28e0a28b1e6d44b7f329b9202cb2add337
   CI_HOST: x86_64-w64-mingw32
 
 jobs:


### PR DESCRIPTION
Update to ["llvm-mingw 20260602 with LLVM 22.1.7"](https://github.com/mstorsjo/llvm-mingw/releases/tag/20260602).