### PR TITLE
Use `actions/build-depends` directly

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -2,7 +2,6 @@ name: FreeBSD
 on:
   pull_request:
     paths:
-      - '.github/actions/build-depends/action.yml'
       - '.github/workflows/freebsd.yml'
   workflow_dispatch:
     inputs:
@@ -196,14 +195,8 @@ jobs:
       - *START_VM
       - *FETCH_SOURCE
 
-      - name: Checkout helper actions
-        uses: actions/checkout@v7
-        with:
-          sparse-checkout: .github/actions/build-depends
-          path: ci/nightly
-
       - name: Build depends
-        uses: ./ci/nightly/.github/actions/build-depends
+        uses: hebasto/bitcoin-core-nightly/.github/actions/build-depends@main
         with:
           vm: freebsd
           source-dir: /root/bitcoin

--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -2,7 +2,6 @@ name: NetBSD
 on:
   pull_request:
     paths:
-      - '.github/actions/build-depends/action.yml'
       - '.github/workflows/netbsd.yml'
   workflow_dispatch:
     inputs:
@@ -163,14 +162,8 @@ jobs:
       - *START_VM
       - *FETCH_SOURCE
 
-      - name: Checkout helper actions
-        uses: actions/checkout@v7
-        with:
-          sparse-checkout: .github/actions/build-depends
-          path: ci/nightly
-
       - name: Build depends
-        uses: ./ci/nightly/.github/actions/build-depends
+        uses: hebasto/bitcoin-core-nightly/.github/actions/build-depends@main
         with:
           vm: netbsd
           options: >

--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -2,7 +2,6 @@ name: OpenBSD
 on:
   pull_request:
     paths:
-      - '.github/actions/build-depends/action.yml'
       - '.github/workflows/openbsd.yml'
   workflow_dispatch:
     inputs:
@@ -201,14 +200,8 @@ jobs:
       - *START_VM
       - *FETCH_SOURCE
 
-      - name: Checkout helper actions
-        uses: actions/checkout@v7
-        with:
-          sparse-checkout: .github/actions/build-depends
-          path: ci/nightly
-
       - name: Build depends
-        uses: ./ci/nightly/.github/actions/build-depends
+        uses: hebasto/bitcoin-core-nightly/.github/actions/build-depends@main
         with:
           vm: openbsd
           source-dir: /home/bitcoin


### PR DESCRIPTION
This simplifies the workflow. As a trade-off, extra care must be taken when modifying `actions/build-depends`.