### PR TITLE
Disable `vmactions/*-vm` caches

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -60,6 +60,7 @@ jobs:
             pkg update
             pkg install -y curl cmake-core ninja pkgconf python3 net/py-pyzmq databases/py-sqlite3 lsof ${{ env.PACKAGES }}
           sync: no
+          disable-cache: true
 
       - &FETCH_SOURCE
         name: Fetch source tarball

--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -65,6 +65,7 @@ jobs:
             pkg_info > packages_after
             diff -w packages_before packages_after | grep '^>'
           sync: no
+          disable-cache: true
 
       # The preinstalled `devel/capnproto` package is broken.
       # See https://github.com/bitcoin-core/libmultiprocess/pull/196.

--- a/.github/workflows/omnios.yml
+++ b/.github/workflows/omnios.yml
@@ -54,6 +54,7 @@ jobs:
           run: git config --global --add safe.directory ${{ github.workspace }}
           sync: 'rsync'
           copyback: false
+          disable-cache: true
 
       - name: Build Boost
         run: |

--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -60,6 +60,7 @@ jobs:
           release: ${{ matrix.release }}
           prepare: pkg_add -U -v curl gtar-- cmake-core ninja python%3 py3-zmq ${{ env.PACKAGES }}
           sync: no
+          disable-cache: true
 
       - &FETCH_SOURCE
         name: Fetch source tarball

--- a/.github/workflows/openindiana.yml
+++ b/.github/workflows/openindiana.yml
@@ -66,6 +66,7 @@ jobs:
           run: git config --global --add safe.directory ${{ github.workspace }}
           sync: 'rsync'
           copyback: false
+          disable-cache: true
 
       - name: Build Boost
         run: |


### PR DESCRIPTION
There is no evidence that these caches significantly speed up the VM startup steps. However, they consume GHA cache storage, potentially forcing the eviction of other caches.