### PR TITLE
build-depends: Use depends' `final_build_id` as cache key

### DIFF
--- a/.github/actions/build-depends/action.yml
+++ b/.github/actions/build-depends/action.yml
@@ -24,21 +24,28 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Determine the depends `final_build_id`
+      id: build_id
+      shell: bash
+      run: |
+        build_id="$(ssh ${{ inputs.vm }} "gmake --no-print-directory -C ${{ inputs.source-dir }}/depends ${{ inputs.host }} ${{ inputs.options }} print-final_build_id" | sed -n 's/^final_build_id=//p')"
+        echo "build_id=${build_id}" >> "$GITHUB_OUTPUT"
+
     - uses: actions/cache/restore@v6
       id: restore-cache
       with:
         path: depends_built
-        key: ${{ inputs.cache-tag }}-depends-${{ hashFiles('depends/**') }}
+        key: ${{ inputs.cache-tag }}-depends-${{ steps.build_id.outputs.build_id }}
 
     - if: steps.restore-cache.outputs.cache-hit == 'true'
-      shell: bash -e {0}
+      shell: bash
       run: rsync --archive --stats depends_built/ ${{ inputs.vm }}:${{ inputs.source-dir }}/depends/built
 
     - shell: ${{ inputs.vm }} {0}
       run: gmake -C ${{ inputs.source-dir }}/depends -j ${{ env.CI_NCPU }} LOG=1 ${{ inputs.host }} ${{ inputs.options }}
 
     - if: steps.restore-cache.outputs.cache-hit != 'true'
-      shell: bash -e {0}
+      shell: bash
       run: rsync --archive --stats ${{ inputs.vm }}:${{ inputs.source-dir }}/depends/built/ depends_built
 
     - if: steps.restore-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -202,6 +202,8 @@ jobs:
         uses: ./ci/nightly/.github/actions/build-depends
         with:
           vm: freebsd
+          options: >-
+            NO_QT=1
           source-dir: /root/bitcoin
           cache-tag: freebsd-${{ matrix.release }}
 
@@ -225,6 +227,7 @@ jobs:
           set(configure_opts
             "--toolchain /root/bitcoin/depends/x86_64-unknown-freebsd${{ matrix.release }}/toolchain.cmake"
             "--preset dev-mode"
+            "-DBUILD_GUI=OFF"
             "-DWITH_USDT=OFF"
             "-DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
           )

--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -246,7 +246,7 @@ jobs:
         uses: ./ci/nightly/.github/actions/build-depends
         with:
           vm: netbsd
-          options: >
+          options: >-
             build_CC=/usr/pkg/gcc14/bin/gcc
             build_CXX=/usr/pkg/gcc14/bin/g++
             CC=/usr/pkg/gcc14/bin/gcc


### PR DESCRIPTION
The current approach has two issues:
1. The `depends` subdirectory is no longer available on the host.
2. `hashFiles('depends/**')` does not take into account changes in the build environment.