### PR TITLE
OpenIndiana: Avoid excessive parallelism in functional tests

### DIFF
--- a/.github/workflows/openindiana.yml
+++ b/.github/workflows/openindiana.yml
@@ -153,7 +153,7 @@ jobs:
         run: |
           cd ${{ github.workspace }}
           # Not running extended tests to avoid disk space issues.
-          python3.14 build/test/functional/test_runner.py -j $((${{ env.CI_NCPU }} * 2)) --combinedlogslen=99999999 \
+          python3.14 build/test/functional/test_runner.py -j ${{ env.CI_NCPU }} --combinedlogslen=99999999 \
             --tmpdirprefix . \
             `# See https://github.com/bitcoin/bitcoin/issues/33128.` \
             --exclude feature_reindex_init \


### PR DESCRIPTION
This is an attempt to mitigate intermittent VM crashes.