### PR TITLE
FreeBSD: Set `CTEST_CONFIGURATION_TYPE` explicitly

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -82,6 +82,7 @@ jobs:
           set(CTEST_SOURCE_DIRECTORY "${CTEST_SCRIPT_DIRECTORY}/bitcoin")
           set(CTEST_BINARY_DIRECTORY "${CTEST_SCRIPT_DIRECTORY}/build")
           set(CTEST_CMAKE_GENERATOR "Ninja")
+          set(CTEST_CONFIGURATION_TYPE "RelWithDebInfo")
           cmake_host_system_information(RESULT nproc QUERY NUMBER_OF_LOGICAL_CORES)
           EOF
 


### PR DESCRIPTION
This prevents a harmless but confusing `--config "Release"` argument from being passed to `cmake --build`.