### PR TITLE
macOS: Switch to `xcode-27` image

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,8 +21,8 @@ concurrency:
 
 jobs:
   macos:
-    name: 'macOS 26 ARM64'
-    runs-on: macos-26
+    name: 'macOS ARM64, Xcode 27'
+    runs-on: xcode-27
 
     steps:
       - name: Checkout Bitcoin Core repo
@@ -39,7 +39,7 @@ jobs:
         run: |
           cat << 'EOF' > ctest_config.cmake
           set(CTEST_SITE "${{ github.repository }}")
-          set(CTEST_BUILD_NAME "macOS 26 ARM64")
+          set(CTEST_BUILD_NAME "macOS ARM64, Xcode 27")
           set(CTEST_SOURCE_DIRECTORY "$ENV{GITHUB_WORKSPACE}")
           set(CTEST_BINARY_DIRECTORY "${CTEST_SOURCE_DIRECTORY}/build")
           set(CTEST_CMAKE_GENERATOR "Unix Makefiles")

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For another repository with nightly builds of Bitcoin Core, see [maflcko/b-c-nig
 
 | Operating System | Status | Notes |
 |------------------|--------|-------|
-| [macOS Tahoe](https://www.apple.com/os/macos/), ARM64 | [![macOS, arm64](https://github.com/hebasto/bitcoin-core-nightly/actions/workflows/macos.yml/badge.svg)](https://github.com/hebasto/bitcoin-core-nightly/actions/workflows/macos.yml?query=event%3Aworkflow_run) | No depends |
+| macOS ARM64, Xcode 27 | [![macOS, arm64](https://github.com/hebasto/bitcoin-core-nightly/actions/workflows/macos.yml/badge.svg)](https://github.com/hebasto/bitcoin-core-nightly/actions/workflows/macos.yml?query=event%3Aworkflow_run) | No depends |
 
 ## [openSUSE](https://www.opensuse.org/)
 


### PR DESCRIPTION
From https://github.blog/changelog/2026-07-16-xcode-27-runner-image-now-in-public-preview/:
> With this release, we are moving to a new support model for our macOS images. Each image is based on a major Xcode version rather than the underlying operating system, and we will support one major Xcode version per image. This makes it easier to target the exact toolchain your project needs and to know what each runner provides.