### PR TITLE
Windows, clang-cl: Work around CMake 4.4 bug

### DIFF
--- a/.github/workflows/windows-clang-cl-arm64.yml
+++ b/.github/workflows/windows-clang-cl-arm64.yml
@@ -92,6 +92,9 @@ jobs:
             "-DBUILD_UTIL_CHAINSTATE=ON"
             "-DBUILD_BENCH=ON"
             "-DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
+            # A workaround for a bug in CMake 4.4.0.
+            # See https://gitlab.kitware.com/cmake/cmake/-/work_items/27957.
+            "-DCMAKE_CXX_SCAN_FOR_MODULES=OFF"
           )
           ctest_start(APPEND)
           ctest_configure(OPTIONS "${configure_opts}")

--- a/.github/workflows/windows-clang-cl-x86_64.yml
+++ b/.github/workflows/windows-clang-cl-x86_64.yml
@@ -91,6 +91,9 @@ jobs:
             "-DBUILD_UTIL_CHAINSTATE=ON"
             "-DBUILD_BENCH=ON"
             "-DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
+            # A workaround for a bug in CMake 4.4.0.
+            # See https://gitlab.kitware.com/cmake/cmake/-/work_items/27957.
+            "-DCMAKE_CXX_SCAN_FOR_MODULES=OFF"
           )
           ctest_start(APPEND)
           ctest_configure(OPTIONS "${configure_opts}")


### PR DESCRIPTION
See https://gitlab.kitware.com/cmake/cmake/-/work_items/27957.

Closes https://github.com/hebasto/bitcoin-core-nightly/issues/311.