### PR TITLE
Clang-SNAPSHOT: Allow `-Wunused-template`

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -87,6 +87,7 @@ jobs:
             "-DBUILD_FUZZ_BINARY=ON"
             "-DWITH_ZMQ=ON"
             "-DWITH_USDT=ON"
+            "-DAPPEND_CXXFLAGS=-Wno-error=unused-template"
             "-DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
           )
           ctest_start(APPEND)


### PR DESCRIPTION
Clang recently enabled `-Wunused-template` under `-Wall` (see https://github.com/llvm/llvm-project/pull/206123, https://github.com/llvm/llvm-project/pull/207848, https://github.com/llvm/llvm-project/pull/208001)