### PR TITLE
OpenBSD: Remove explicit exclusion of "*_bind*" tests

### DIFF
--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -207,9 +207,6 @@ jobs:
             --exclude feature_reindex_init \
             `# interface_rest intermittently hangs since 2025-10-23. Running separately in the next command.` \
             --exclude interface_rest \
-            `# Disable tests using lsof, as this package is not available.` \
-            --exclude feature_bind_extra \
-            --exclude rpc_bind \
             --timeout-factor=8
           /home/build/test/functional/test_runner.py interface_rest --combinedlogslen=99999999 \
             --tmpdirprefix /home \


### PR DESCRIPTION
Since https://github.com/bitcoin/bitcoin/pull/35216, the test framework is capable of recognizing the absence of the `lsof` package.