### PR TITLE
Windows: Install vcpkg packages in classic mode and switch to `dev-mode` preset

### DIFF
--- a/.github/workflows/windows-clang-cl-arm64.yml
+++ b/.github/workflows/windows-clang-cl-arm64.yml
@@ -28,6 +28,11 @@ jobs:
         shell: pwsh -Command "$PSNativeCommandUseErrorActionPreference = $true; $ErrorActionPreference = 'Stop'; & '{0}'"
 
     steps:
+      - name: Install dependencies
+        run: |
+          Add-Content -Path "$env:VCPKG_INSTALLATION_ROOT\triplets\arm64-windows.cmake" -Value "set(VCPKG_BUILD_TYPE release)"
+          vcpkg install boost-multi-index boost-test sqlite3[core] zeromq qtbase[core,gui,network,png,testlib,widgets] qttools libqrencode
+
       - name: Checkout Bitcoin Core repo
         uses: actions/checkout@v7
         with:
@@ -40,10 +45,6 @@ jobs:
         run: |
           $commit = git rev-parse HEAD~1
           "commit=$commit" >> $env:GITHUB_OUTPUT
-
-      - name: Set vcpkg build type
-        run: |
-          Add-Content -Path "$env:VCPKG_INSTALLATION_ROOT\triplets\arm64-windows.cmake" -Value "set(VCPKG_BUILD_TYPE release)"
 
       - name: Generate CTest configuration
         run: |
@@ -71,11 +72,12 @@ jobs:
           include("$ENV{GITHUB_WORKSPACE}/ctest_config.cmake")
           set(ENV{CXXFLAGS} "-Wno-return-type -Wno-error=conditional-uninitialized")
           set(configure_opts
-            "--preset windows"
+            "-T ClangCL"
+            "--preset dev-mode"
+            "-DWITH_USDT=OFF"
             "--toolchain $ENV{VCPKG_INSTALLATION_ROOT}\\scripts\\buildsystems\\vcpkg.cmake"
+            "-DVCPKG_MANIFEST_MODE=OFF"
             "-DVCPKG_TARGET_TRIPLET=arm64-windows"
-            "-DBUILD_UTIL_CHAINSTATE=ON"
-            "-DBUILD_BENCH=ON"
             "-DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
             # A workaround for a bug in CMake 4.4.0.
             # See https://gitlab.kitware.com/cmake/cmake/-/work_items/27957.

--- a/.github/workflows/windows-clang-cl-x86_64.yml
+++ b/.github/workflows/windows-clang-cl-x86_64.yml
@@ -28,6 +28,11 @@ jobs:
         shell: pwsh -Command "$PSNativeCommandUseErrorActionPreference = $true; $ErrorActionPreference = 'Stop'; & '{0}'"
 
     steps:
+      - name: Install dependencies
+        run: |
+          Add-Content -Path "$env:VCPKG_INSTALLATION_ROOT\triplets\x64-windows.cmake" -Value "set(VCPKG_BUILD_TYPE release)"
+          vcpkg install boost-multi-index boost-test sqlite3[core] zeromq qtbase[core,gui,network,png,testlib,widgets] qttools libqrencode
+
       - name: Checkout Bitcoin Core repo
         uses: actions/checkout@v7
         with:
@@ -40,10 +45,6 @@ jobs:
         run: |
           $commit = git rev-parse HEAD~1
           "commit=$commit" >> $env:GITHUB_OUTPUT
-
-      - name: Set vcpkg build type
-        run: |
-          Add-Content -Path "$env:VCPKG_INSTALLATION_ROOT\triplets\x64-windows.cmake" -Value "set(VCPKG_BUILD_TYPE release)"
 
       - name: Generate CTest configuration
         run: |
@@ -71,10 +72,12 @@ jobs:
           include("$ENV{GITHUB_WORKSPACE}/ctest_config.cmake")
           set(ENV{CXXFLAGS} "-Wno-return-type -Wno-error=conditional-uninitialized")
           set(configure_opts
-            "--preset windows"
+            "-T ClangCL"
+            "--preset dev-mode"
+            "-DWITH_USDT=OFF"
             "--toolchain $ENV{VCPKG_INSTALLATION_ROOT}\\scripts\\buildsystems\\vcpkg.cmake"
-            "-DBUILD_UTIL_CHAINSTATE=ON"
-            "-DBUILD_BENCH=ON"
+            "-DVCPKG_MANIFEST_MODE=OFF"
+            "-DVCPKG_TARGET_TRIPLET=x64-windows"
             "-DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
             # A workaround for a bug in CMake 4.4.0.
             # See https://gitlab.kitware.com/cmake/cmake/-/work_items/27957.

--- a/.github/workflows/windows-msvc-x86_64.yml
+++ b/.github/workflows/windows-msvc-x86_64.yml
@@ -22,6 +22,10 @@ jobs:
         shell: pwsh -Command "$PSNativeCommandUseErrorActionPreference = $true; $ErrorActionPreference = 'Stop'; & '{0}'"
 
     steps:
+      - name: Install dependencies
+        run: |
+          vcpkg install boost-multi-index boost-test sqlite3[core] zeromq qtbase[core,gui,network,png,testlib,widgets] qttools libqrencode
+
       - name: Checkout Bitcoin Core repo
         uses: actions/checkout@v7
         with:
@@ -52,10 +56,10 @@ jobs:
         run: |
           include("$ENV{GITHUB_WORKSPACE}/ctest_config.cmake")
           set(configure_opts
-            "--preset vs2026"
+            "--preset dev-mode"
+            "-DWITH_USDT=OFF"
             "--toolchain $ENV{VCPKG_INSTALLATION_ROOT}\\scripts\\buildsystems\\vcpkg.cmake"
-            "-DBUILD_UTIL_CHAINSTATE=ON"
-            "-DBUILD_BENCH=ON"
+            "-DVCPKG_MANIFEST_MODE=OFF"
             "-DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
           )
           ctest_start(APPEND)


### PR DESCRIPTION
This PR enables building against the latest versions of dependencies available via vcpkg.