### PR TITLE
Revert "Windows, clang-cl: Work around CMake 4.4 bug"

### DIFF
--- a/.github/workflows/windows-clang-cl-arm64.yml
+++ b/.github/workflows/windows-clang-cl-arm64.yml
@@ -79,9 +79,6 @@ jobs:
             "-DVCPKG_MANIFEST_MODE=OFF"
             "-DVCPKG_TARGET_TRIPLET=arm64-windows"
             "-DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
-            # A workaround for a bug in CMake 4.4.0.
-            # See https://gitlab.kitware.com/cmake/cmake/-/work_items/27957.
-            "-DCMAKE_CXX_SCAN_FOR_MODULES=OFF"
           )
           ctest_start(APPEND)
           ctest_configure(OPTIONS "${configure_opts}")

--- a/.github/workflows/windows-clang-cl-x86_64.yml
+++ b/.github/workflows/windows-clang-cl-x86_64.yml
@@ -79,9 +79,6 @@ jobs:
             "-DVCPKG_MANIFEST_MODE=OFF"
             "-DVCPKG_TARGET_TRIPLET=x64-windows"
             "-DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
-            # A workaround for a bug in CMake 4.4.0.
-            # See https://gitlab.kitware.com/cmake/cmake/-/work_items/27957.
-            "-DCMAKE_CXX_SCAN_FOR_MODULES=OFF"
           )
           ctest_start(APPEND)
           ctest_configure(OPTIONS "${configure_opts}")


### PR DESCRIPTION
This reverts commit 98dcb2f6c6c6bdaa97253624a1cfe1887c7dcf48.

The [bug](https://gitlab.kitware.com/cmake/cmake/-/work_items/27957) has been [fixed](https://gitlab.kitware.com/cmake/cmake/-/merge_requests/12301) in CMake 4.4.1.