### PR TITLE
Windows, LLVM: Update LLVM MinGW toolchain

### DIFF
--- a/.github/workflows/windows-llvm-arm64.yml
+++ b/.github/workflows/windows-llvm-arm64.yml
@@ -20,8 +20,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CI_LLVM_MINGW_URL: https://github.com/mstorsjo/llvm-mingw/releases/download/20260728/llvm-mingw-20260728-ucrt-ubuntu-22.04-x86_64.tar.xz
-  CI_LLVM_MINGW_HASH: bdc15cb613f2ef309827a90d409806a45eb68e4e607c290fa1b933d74ab87846
+  CI_LLVM_MINGW_URL: https://github.com/mstorsjo/llvm-mingw/releases/download/20260812/llvm-mingw-20260812-ucrt-ubuntu-22.04-x86_64.tar.xz
+  CI_LLVM_MINGW_HASH: 3c67656225ad4000c9f5acabddf0862af59ab201eb5611915ca12915747627f6
   CI_HOST: aarch64-w64-mingw32
 
 jobs:

--- a/.github/workflows/windows-llvm-x86_64.yml
+++ b/.github/workflows/windows-llvm-x86_64.yml
@@ -20,8 +20,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CI_LLVM_MINGW_URL: https://github.com/mstorsjo/llvm-mingw/releases/download/20260728/llvm-mingw-20260728-ucrt-ubuntu-22.04-x86_64.tar.xz
-  CI_LLVM_MINGW_HASH: bdc15cb613f2ef309827a90d409806a45eb68e4e607c290fa1b933d74ab87846
+  CI_LLVM_MINGW_URL: https://github.com/mstorsjo/llvm-mingw/releases/download/20260812/llvm-mingw-20260812-ucrt-ubuntu-22.04-x86_64.tar.xz
+  CI_LLVM_MINGW_HASH: 3c67656225ad4000c9f5acabddf0862af59ab201eb5611915ca12915747627f6
   CI_HOST: x86_64-w64-mingw32
 
 jobs:


### PR DESCRIPTION
Update to ["llvm-mingw 20260812 with LLVM 23.1.0 RC 3"](https://github.com/mstorsjo/llvm-mingw/releases/tag/20260812).